### PR TITLE
Fix section symbol in regex when compiled with Angular

### DIFF
--- a/lib/utilities/text-helper.ts
+++ b/lib/utilities/text-helper.ts
@@ -1,6 +1,6 @@
 export class TextHelper {
     getPropertyNameRegex(): RegExp {
-        return /[\&\(\)\?\-\=\'\"\§\!\%\:\_\s.]+(.)?/g;
+        return /[\&\(\)\?\-\=\'\"\\\xa7\!\%\:\_\s.]+(.)?/g;
     }
 
     removeZeroWidthCharacters(str: string): string {


### PR DESCRIPTION
### Motivation

For some reason, Angular translates the section symbol in the property name regex to `\xa7`, I assume to escape it, however this causes the regex to match against any `a` in the property name. In this commit I fixed it so that the regex already includes the escaping, so Angular doesn't try to escape it. We are using this in our system and it works great.

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [X] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

We found this issue using the camelCasePropertyNameResolver in an Angular project. Any field that had the letter `a` in it had property name resolver issues.
