### PR TITLE
Feature/rich text linked item order

### DIFF
--- a/lib/mappers/element.mapper.ts
+++ b/lib/mappers/element.mapper.ts
@@ -157,12 +157,12 @@ export class ElementMapper {
         const richTextLinkedItemsCodenames: string[] = [];
 
         const rawModularContentCodenamesMatches = (rawElement.value as string).matchAll(
-            /<object[^>]+data-codename=\"(?<codenames>[a-z0-9_]*)\".*?>/g
+            /<object[^>]+data-codename=\"(?<codename>[a-z0-9_]*)\".*?>/g
         );
         const rawModularContentCodenames = Array.from(rawModularContentCodenamesMatches).reduce<string[]>(
             (acc, match) => {
-                if (match?.groups?.codenames) {
-                    acc.push(match?.groups?.codenames);
+                if (match.groups && match.groups.codename) {
+                    acc.push(match.groups.codename);
                 }
                 return acc;
             },

--- a/lib/mappers/element.mapper.ts
+++ b/lib/mappers/element.mapper.ts
@@ -150,12 +150,27 @@ export class ElementMapper {
         processingStartedForCodenames: string[],
         preparedItems: IContentItemWithRawDataContainer
     ): Elements.RichTextElement {
-        // get all linked items nested in rich text
-        const richTextLinkedItems: IContentItem[] = [];
-
         const rawElement = elementWrapper.rawElement as Contracts.IRichTextElementContract;
 
-        for (const codename of rawElement.modular_content) {
+        // get all linked items nested in rich text
+        const richTextLinkedItems: IContentItem[] = [];
+        const richTextLinkedItemsCodenames: string[] = [];
+
+        const rawModularContentCodenamesMatches = (rawElement.value as string).matchAll(
+            /<object[^>]+data-codename=\"(?<codenames>[a-z0-9_]*)\".*?>/g
+        );
+        const rawModularContentCodenames = Array.from(rawModularContentCodenamesMatches).reduce<string[]>(
+            (acc, match) => {
+                if (match?.groups?.codenames) {
+                    acc.push(match?.groups?.codenames);
+                }
+                return acc;
+            },
+            [] as string[]
+        );
+
+        for (const codename of rawModularContentCodenames) {
+            richTextLinkedItemsCodenames.push(codename);
             // get linked item and check if it exists (it might not be included in response due to 'Depth' parameter)
             const preparedData = preparedItems[codename];
 
@@ -203,7 +218,7 @@ export class ElementMapper {
 
         return {
             images: images,
-            linkedItemCodenames: rawElement.modular_content,
+            linkedItemCodenames: richTextLinkedItemsCodenames,
             linkedItems: richTextLinkedItems,
             links: links,
             name: rawElement.name,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10655,7 +10655,8 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
             "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@webpack-cli/info": {
             "version": "1.5.0",
@@ -10670,7 +10671,8 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
             "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@xtuc/ieee754": {
             "version": "1.2.0",
@@ -10704,7 +10706,8 @@
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
             "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "acorn-walk": {
             "version": "8.2.0",
@@ -10734,7 +10737,8 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "ansi-colors": {
             "version": "4.1.1",
@@ -13343,7 +13347,8 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-1.7.0.tgz",
             "integrity": "sha512-pzum1TL7j90DTE86eFt48/s12hqwQuiD+e5aXx2Dc9wDEn2LfGq6RoAxEZZjFiN0RDSCOnosEKRZWxbQ+iMpQQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "karma-sourcemap-loader": {
             "version": "0.3.8",
@@ -15771,7 +15776,8 @@
                     "version": "7.5.8",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
                     "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {}
                 }
             }
         },
@@ -15920,7 +15926,8 @@
             "version": "8.2.3",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
             "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "xtend": {
             "version": "4.0.2",

--- a/test/browser/isolated-tests/elements/rich-text/rich-text.spec.json
+++ b/test/browser/isolated-tests/elements/rich-text/rich-text.spec.json
@@ -71,28 +71,6 @@
                     "value": "<p>Basic formatted text: plain text, <strong>bold</strong>, <em>italics</em>, <code>monospace</code>, <sub>subscript</sub>, <sup>superscript</sup>.</p> <p>Links: <a data-item-id=\"ef23e568-6aa2-42cd-a120-7823c0ef19f7\" href=\"\">link to a content item</a>, <a href=\"https://kontent.ai/\" data-new-window=\"true\" target=\"_blank\" rel=\"noopener noreferrer\">link to web URL</a>, <a data-email-address=\"sales@kontent.ai\" href=\"mailto:sales@kontent.ai\">email link</a>, <a data-asset-id=\"237362b4-5f2b-480e-a1d3-0ad5a6d5f8bd\" href=\"https://assets-us-01.kc-usercontent.com:443/38af179c-40ba-42e7-a5ca-33b8cdcc0d45/237362b4-5f2b-480e-a1d3-0ad5a6d5f8bd/image.jpg\">link to asset</a>.</p> <p>Table</p> <table><tbody> <tr><td>A</td><td>B</td><td>C</td></tr> <tr><td>D</td><td>E</td><td>F</td></tr> <tr><td>G</td><td>H</td><td>I</td></tr> </tbody></table> <p>Image</p> <figure data-asset-id=\"66d73245-10e5-4478-93e7-5609fee3cdf7\" data-image-id=\"66d73245-10e5-4478-93e7-5609fee3cdf7\"><img src=\"https://assets-us-01.kc-usercontent.com:443/38af179c-40ba-42e7-a5ca-33b8cdcc0d45/66d73245-10e5-4478-93e7-5609fee3cdf7/image.jpg\" data-asset-id=\"66d73245-10e5-4478-93e7-5609fee3cdf7\" data-image-id=\"66d73245-10e5-4478-93e7-5609fee3cdf7\" alt=\"\"></figure> <p>Component</p></object><object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n1\"></object><object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n2\"></object><object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n3\"></object><p>Inserted content item</p> <object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"link\" data-codename=\"n4\"></object>"
                 }
             }
-        },
-        {
-            "system": {
-                "id": "a3dde145-2456-445d-ac33-3d3f6a092da9",
-                "name": "Rich Text Item (Empty)",
-                "codename": "rich_text_item_empty",
-                "language": "default",
-                "type": "item",
-                "sitemap_locations": [],
-                "collection": "default",
-                "last_modified": "2019-01-04T09:56:04.372261Z"
-            },
-            "elements": {
-                "rich": {
-                    "type": "rich_text",
-                    "name": "Rich",
-                    "images": {},
-                    "links": {},
-                    "modular_content": [],
-                    "value": "<p><br></p>"
-                }
-            }
         }
     ],
     "modular_content": {

--- a/test/browser/isolated-tests/elements/rich-text/rich-text.spec.json
+++ b/test/browser/isolated-tests/elements/rich-text/rich-text.spec.json
@@ -1,0 +1,135 @@
+{
+    "items": [
+        {
+            "system": {
+                "id": "a3dde145-2456-445d-ac33-3d3f6a092da7",
+                "name": "Rich Text Item (Unordered)",
+                "codename": "rich_text_item_unordered",
+                "language": "default",
+                "type": "item",
+                "sitemap_locations": [],
+                "collection": "default",
+                "last_modified": "2019-01-04T09:56:04.372261Z"
+            },
+            "elements": {
+                "rich": {
+                    "type": "rich_text",
+                    "name": "Rich",
+                    "images": {},
+                    "links": {},
+                    "modular_content": ["n2", "n3", "n1"],
+                    "value": "<object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n1\"></object><object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n2\"></object><object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n3\"></object>"
+                }
+            }
+        },
+        {
+            "system": {
+                "id": "a3dde145-2456-445d-ac33-3d3f6a092da8",
+                "name": "Rich Text Item (Ordered)",
+                "codename": "rich_text_item_ordered",
+                "language": "default",
+                "type": "item",
+                "sitemap_locations": [],
+                "collection": "default",
+                "last_modified": "2019-01-04T09:56:04.372261Z"
+            },
+            "elements": {
+                "rich": {
+                    "type": "rich_text",
+                    "name": "Rich",
+                    "images": {},
+                    "links": {},
+                    "modular_content": ["n1", "n2", "n3"],
+                    "value": "<object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n1\"></object><object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n2\"></object><object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n3\"></object>"
+                }
+            }
+        },
+        {
+            "system": {
+                "id": "a3dde145-2456-445d-ac33-3d3f6a092da9",
+                "name": "Rich Text Item (Empty)",
+                "codename": "rich_text_item_empty",
+                "language": "default",
+                "type": "item",
+                "sitemap_locations": [],
+                "collection": "default",
+                "last_modified": "2019-01-04T09:56:04.372261Z"
+            },
+            "elements": {
+                "rich": {
+                    "type": "rich_text",
+                    "name": "Rich",
+                    "images": {},
+                    "links": {},
+                    "modular_content": [],
+                    "value": "<p><br></p>"
+                }
+            }
+        }
+    ],
+    "modular_content": {
+        "n1": {
+            "system": {
+                "id": "a3dde145-2456-445d-ac33-3d3f6a092da8-n1",
+                "name": "Modular Content 1",
+                "codename": "n1",
+                "language": "default",
+                "type": "modular_item",
+                "sitemap_locations": [],
+                "collection": "default",
+                "last_modified": "2019-01-04T09:56:04.372261Z"
+            },
+            "elements": {
+                "text": {
+                    "type": "text",
+                    "name": "Text",
+                    "value": "Text 1"
+                }
+            }
+        },
+        "n2": {
+            "system": {
+                "id": "a3dde245-2456-445d-ac33-3d3f6a092da8-n2",
+                "name": "Modular Content 2",
+                "codename": "n2",
+                "language": "default",
+                "type": "modular_item",
+                "sitemap_locations": [],
+                "collection": "default",
+                "last_modified": "2019-01-04T09:56:04.372261Z"
+            },
+            "elements": {
+                "text": {
+                    "type": "text",
+                    "name": "Text",
+                    "value": "Text 2"
+                }
+            }
+        },
+        "n3": {
+            "system": {
+                "id": "a3dde345-2456-445d-ac33-3d3f6a092da8-n3",
+                "name": "Modular Content 3",
+                "codename": "n3",
+                "language": "default",
+                "type": "modular_item",
+                "sitemap_locations": [],
+                "collection": "default",
+                "last_modified": "2019-01-04T09:56:04.372261Z"
+            },
+            "elements": {
+                "text": {
+                    "type": "text",
+                    "name": "Text",
+                    "value": "Text 3"
+                }
+            }
+        }
+    },
+    "pagination": {
+        "skip": 0,
+        "limit": 0,
+        "count": 3,
+        "next_page": ""
+    }
+}

--- a/test/browser/isolated-tests/elements/rich-text/rich-text.spec.json
+++ b/test/browser/isolated-tests/elements/rich-text/rich-text.spec.json
@@ -15,10 +15,24 @@
                 "rich": {
                     "type": "rich_text",
                     "name": "Rich",
-                    "images": {},
-                    "links": {},
-                    "modular_content": ["n2", "n3", "n1"],
-                    "value": "<object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n1\"></object><object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n2\"></object><object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n3\"></object>"
+                    "images": {
+                        "66d73245-10e5-4478-93e7-5609fee3cdf7": {
+                            "image_id": "66d73245-10e5-4478-93e7-5609fee3cdf7",
+                            "description": null,
+                            "url": "https://assets-us-01.kc-usercontent.com:443/38af179c-40ba-42e7-a5ca-33b8cdcc0d45/66d73245-10e5-4478-93e7-5609fee3cdf7/image.jpg",
+                            "width": 600,
+                            "height": 457
+                        }
+                    },
+                    "links": {
+                        "ef23e568-6aa2-42cd-a120-7823c0ef19f7": {
+                            "codename": "article_codename",
+                            "type": "article",
+                            "url_slug": "my-article"
+                        }
+                    },
+                    "modular_content": ["n2", "n4", "n3", "n1"],
+                    "value": "<p>Basic formatted text: plain text, <strong>bold</strong>, <em>italics</em>, <code>monospace</code>, <sub>subscript</sub>, <sup>superscript</sup>.</p> <p>Links: <a data-item-id=\"ef23e568-6aa2-42cd-a120-7823c0ef19f7\" href=\"\">link to a content item</a>, <a href=\"https://kontent.ai/\" data-new-window=\"true\" target=\"_blank\" rel=\"noopener noreferrer\">link to web URL</a>, <a data-email-address=\"sales@kontent.ai\" href=\"mailto:sales@kontent.ai\">email link</a>, <a data-asset-id=\"237362b4-5f2b-480e-a1d3-0ad5a6d5f8bd\" href=\"https://assets-us-01.kc-usercontent.com:443/38af179c-40ba-42e7-a5ca-33b8cdcc0d45/237362b4-5f2b-480e-a1d3-0ad5a6d5f8bd/image.jpg\">link to asset</a>.</p> <p>Table</p> <table><tbody> <tr><td>A</td><td>B</td><td>C</td></tr> <tr><td>D</td><td>E</td><td>F</td></tr> <tr><td>G</td><td>H</td><td>I</td></tr> </tbody></table> <p>Image</p> <figure data-asset-id=\"66d73245-10e5-4478-93e7-5609fee3cdf7\" data-image-id=\"66d73245-10e5-4478-93e7-5609fee3cdf7\"><img src=\"https://assets-us-01.kc-usercontent.com:443/38af179c-40ba-42e7-a5ca-33b8cdcc0d45/66d73245-10e5-4478-93e7-5609fee3cdf7/image.jpg\" data-asset-id=\"66d73245-10e5-4478-93e7-5609fee3cdf7\" data-image-id=\"66d73245-10e5-4478-93e7-5609fee3cdf7\" alt=\"\"></figure> <p>Component</p></object><object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n1\"></object><object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n2\"></object><object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n3\"></object><p>Inserted content item</p> <object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"link\" data-codename=\"n4\"></object>"
                 }
             }
         },
@@ -37,10 +51,24 @@
                 "rich": {
                     "type": "rich_text",
                     "name": "Rich",
-                    "images": {},
-                    "links": {},
-                    "modular_content": ["n1", "n2", "n3"],
-                    "value": "<object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n1\"></object><object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n2\"></object><object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n3\"></object>"
+                    "images": {
+                        "66d73245-10e5-4478-93e7-5609fee3cdf7": {
+                            "image_id": "66d73245-10e5-4478-93e7-5609fee3cdf7",
+                            "description": null,
+                            "url": "https://assets-us-01.kc-usercontent.com:443/38af179c-40ba-42e7-a5ca-33b8cdcc0d45/66d73245-10e5-4478-93e7-5609fee3cdf7/image.jpg",
+                            "width": 600,
+                            "height": 457
+                        }
+                    },
+                    "links": {
+                        "ef23e568-6aa2-42cd-a120-7823c0ef19f7": {
+                            "codename": "n4",
+                            "type": "article",
+                            "url_slug": "my-article"
+                        }
+                    },
+                    "modular_content": ["n1", "n2", "n3", "n4"],
+                    "value": "<p>Basic formatted text: plain text, <strong>bold</strong>, <em>italics</em>, <code>monospace</code>, <sub>subscript</sub>, <sup>superscript</sup>.</p> <p>Links: <a data-item-id=\"ef23e568-6aa2-42cd-a120-7823c0ef19f7\" href=\"\">link to a content item</a>, <a href=\"https://kontent.ai/\" data-new-window=\"true\" target=\"_blank\" rel=\"noopener noreferrer\">link to web URL</a>, <a data-email-address=\"sales@kontent.ai\" href=\"mailto:sales@kontent.ai\">email link</a>, <a data-asset-id=\"237362b4-5f2b-480e-a1d3-0ad5a6d5f8bd\" href=\"https://assets-us-01.kc-usercontent.com:443/38af179c-40ba-42e7-a5ca-33b8cdcc0d45/237362b4-5f2b-480e-a1d3-0ad5a6d5f8bd/image.jpg\">link to asset</a>.</p> <p>Table</p> <table><tbody> <tr><td>A</td><td>B</td><td>C</td></tr> <tr><td>D</td><td>E</td><td>F</td></tr> <tr><td>G</td><td>H</td><td>I</td></tr> </tbody></table> <p>Image</p> <figure data-asset-id=\"66d73245-10e5-4478-93e7-5609fee3cdf7\" data-image-id=\"66d73245-10e5-4478-93e7-5609fee3cdf7\"><img src=\"https://assets-us-01.kc-usercontent.com:443/38af179c-40ba-42e7-a5ca-33b8cdcc0d45/66d73245-10e5-4478-93e7-5609fee3cdf7/image.jpg\" data-asset-id=\"66d73245-10e5-4478-93e7-5609fee3cdf7\" data-image-id=\"66d73245-10e5-4478-93e7-5609fee3cdf7\" alt=\"\"></figure> <p>Component</p></object><object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n1\"></object><object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n2\"></object><object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"n3\"></object><p>Inserted content item</p> <object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"link\" data-codename=\"n4\"></object>"
                 }
             }
         },
@@ -122,6 +150,25 @@
                     "type": "text",
                     "name": "Text",
                     "value": "Text 3"
+                }
+            }
+        },
+        "n4": {
+            "system": {
+                "id": "a3dde345-2456-445d-ac33-3d3f6a092da8-n4",
+                "name": "Modular Content 4",
+                "codename": "n4",
+                "language": "default",
+                "type": "modular_item",
+                "sitemap_locations": [],
+                "collection": "default",
+                "last_modified": "2019-01-04T09:56:04.372261Z"
+            },
+            "elements": {
+                "text": {
+                    "type": "text",
+                    "name": "Text",
+                    "value": "Text 4"
                 }
             }
         }

--- a/test/browser/isolated-tests/elements/rich-text/rich-text.spec.ts
+++ b/test/browser/isolated-tests/elements/rich-text/rich-text.spec.ts
@@ -1,0 +1,46 @@
+import { Responses, Elements, ElementType, IContentItem } from '../../../../../lib';
+import { getDeliveryClientWithJson } from '../../../setup';
+import * as responseJson from './rich-text.spec.json';
+
+describe('Rich Text element', () => {
+    let response: Responses.IListContentItemsResponse;
+    beforeAll(async () => {
+        response = (await getDeliveryClientWithJson(responseJson).items().toPromise()).data;
+    });
+
+    it(`Rich-textlinked items should be re-ordered if order in response`, async () => {
+        const item = response.items.find(
+            ({ system: { codename } }) => codename === 'rich_text_item_unordered'
+        ) as IContentItem;
+        const element = item.elements.rich as Elements.RichTextElement;
+
+        expect(element.type).toEqual(ElementType.RichText);
+        expect(element.linkedItemCodenames).toEqual(['n1', 'n2', 'n3']);
+        for (var i = 0; i < element.linkedItems.length; ++i) {
+            expect(element.linkedItems[i].system.codename).toBe(`n${i + 1}`);
+        }
+    });
+
+    it(`Rich-text linked items order should be maintained if already ordered in response`, () => {
+        const item = response.items.find(
+            ({ system: { codename } }) => codename === 'rich_text_item_ordered'
+        ) as IContentItem;
+        const element = item.elements.rich as Elements.RichTextElement;
+
+        expect(element.type).toEqual(ElementType.RichText);
+        expect(element.linkedItemCodenames).toEqual(['n1', 'n2', 'n3']);
+        for (var i = 0; i < element.linkedItems.length; ++i) {
+            expect(element.linkedItems[i].system.codename).toBe(`n${i + 1}`);
+        }
+    });
+
+    it(`Rich-text mapper should not throw error if value is empty`, () => {
+        const item = response.items.find(
+            ({ system: { codename } }) => codename === 'rich_text_item_empty'
+        ) as IContentItem;
+        const element = item.elements.rich as Elements.RichTextElement;
+
+        expect(element.type).toEqual(ElementType.RichText);
+        expect(element.linkedItemCodenames).toEqual([]);
+    });
+});

--- a/test/browser/isolated-tests/elements/rich-text/rich-text.spec.ts
+++ b/test/browser/isolated-tests/elements/rich-text/rich-text.spec.ts
@@ -9,12 +9,14 @@ describe('Rich-text element', () => {
     });
 
     it(`Rich-text linked items should be re-ordered if not ordered in raw response`, async () => {
+        const rawItem = responseJson.items.find(({ system: { codename } }) => codename === 'rich_text_item_unordered');
         const item = response.items.find(
             ({ system: { codename } }) => codename === 'rich_text_item_unordered'
         ) as IContentItem;
         const element = item.elements.rich as Elements.RichTextElement;
 
         expect(element.type).toEqual(ElementType.RichText);
+        expect(rawItem?.elements.rich.modular_content).toEqual(['n2', 'n4', 'n3', 'n1']);
         expect(element.linkedItemCodenames).toEqual(['n1', 'n2', 'n3', 'n4']);
         for (var i = 0; i < element.linkedItems.length; ++i) {
             expect(element.linkedItems[i].system.codename).toBe(`n${i + 1}`);
@@ -22,12 +24,14 @@ describe('Rich-text element', () => {
     });
 
     it(`Rich-text linked items order should be maintained if already ordered in raw response`, () => {
+        const rawItem = responseJson.items.find(({ system: { codename } }) => codename === 'rich_text_item_ordered');
         const item = response.items.find(
             ({ system: { codename } }) => codename === 'rich_text_item_ordered'
         ) as IContentItem;
         const element = item.elements.rich as Elements.RichTextElement;
 
         expect(element.type).toEqual(ElementType.RichText);
+        expect(rawItem?.elements.rich.modular_content).toEqual(['n1', 'n2', 'n3', 'n4']);
         expect(element.linkedItemCodenames).toEqual(['n1', 'n2', 'n3', 'n4']);
         for (var i = 0; i < element.linkedItems.length; ++i) {
             expect(element.linkedItems[i].system.codename).toBe(`n${i + 1}`);

--- a/test/browser/isolated-tests/elements/rich-text/rich-text.spec.ts
+++ b/test/browser/isolated-tests/elements/rich-text/rich-text.spec.ts
@@ -15,7 +15,7 @@ describe('Rich Text element', () => {
         const element = item.elements.rich as Elements.RichTextElement;
 
         expect(element.type).toEqual(ElementType.RichText);
-        expect(element.linkedItemCodenames).toEqual(['n1', 'n2', 'n3']);
+        expect(element.linkedItemCodenames).toEqual(['n1', 'n2', 'n3', 'n4']);
         for (var i = 0; i < element.linkedItems.length; ++i) {
             expect(element.linkedItems[i].system.codename).toBe(`n${i + 1}`);
         }
@@ -28,7 +28,7 @@ describe('Rich Text element', () => {
         const element = item.elements.rich as Elements.RichTextElement;
 
         expect(element.type).toEqual(ElementType.RichText);
-        expect(element.linkedItemCodenames).toEqual(['n1', 'n2', 'n3']);
+        expect(element.linkedItemCodenames).toEqual(['n1', 'n2', 'n3', 'n4']);
         for (var i = 0; i < element.linkedItems.length; ++i) {
             expect(element.linkedItems[i].system.codename).toBe(`n${i + 1}`);
         }

--- a/test/browser/isolated-tests/elements/rich-text/rich-text.spec.ts
+++ b/test/browser/isolated-tests/elements/rich-text/rich-text.spec.ts
@@ -2,13 +2,13 @@ import { Responses, Elements, ElementType, IContentItem } from '../../../../../l
 import { getDeliveryClientWithJson } from '../../../setup';
 import * as responseJson from './rich-text.spec.json';
 
-describe('Rich Text element', () => {
+describe('Rich-text element', () => {
     let response: Responses.IListContentItemsResponse;
     beforeAll(async () => {
         response = (await getDeliveryClientWithJson(responseJson).items().toPromise()).data;
     });
 
-    it(`Rich-textlinked items should be re-ordered if order in response`, async () => {
+    it(`Rich-text linked items should be re-ordered if not ordered in raw response`, async () => {
         const item = response.items.find(
             ({ system: { codename } }) => codename === 'rich_text_item_unordered'
         ) as IContentItem;
@@ -21,7 +21,7 @@ describe('Rich Text element', () => {
         }
     });
 
-    it(`Rich-text linked items order should be maintained if already ordered in response`, () => {
+    it(`Rich-text linked items order should be maintained if already ordered in raw response`, () => {
         const item = response.items.find(
             ({ system: { codename } }) => codename === 'rich_text_item_ordered'
         ) as IContentItem;
@@ -32,15 +32,5 @@ describe('Rich Text element', () => {
         for (var i = 0; i < element.linkedItems.length; ++i) {
             expect(element.linkedItems[i].system.codename).toBe(`n${i + 1}`);
         }
-    });
-
-    it(`Rich-text mapper should not throw error if value is empty`, () => {
-        const item = response.items.find(
-            ({ system: { codename } }) => codename === 'rich_text_item_empty'
-        ) as IContentItem;
-        const element = item.elements.rich as Elements.RichTextElement;
-
-        expect(element.type).toEqual(ElementType.RichText);
-        expect(element.linkedItemCodenames).toEqual([]);
     });
 });


### PR DESCRIPTION
### Motivation

This PR aims to ensure that the order of the rich-text `linkedItems` and `linkedItemsCodenames` arrays match the order in which the items/components appear in the rich-text `value` property.

See this issue for more details: https://github.com/kontent-ai/delivery-sdk-js/issues/355

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable) - N/A
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Added unit tests to make sure the order of the `modular_content` items is fixed in the Rich Text `linkedItems` and `linkedItemsCodenames` properties of the resolved items. Testing it with live data can be a bit hit and miss as the Kontent Delivery JS API sometimes matches the order of the items in the rich text and sometimes doesn't. @Enngage Let me know if those tests should be added somewhere else in the repo 😄 