### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ const deliveryClient = createDeliveryClient({
 const response = await deliveryClient.items<Movie>().type('<CONTENT_TYPE_CODENAME>').toPromise();
 
 // read data of first item
-const movieText = response.data.items[0].title.value;
+const movieText = response.data.items[0].elements.title.value;
 ```
 
 ## JavaScript & CommonJS
@@ -100,7 +100,7 @@ const response = await deliveryClient.items()
   .toPromise();
 
 // read data of first item
-const movieText = response.data.items[0].title.value;
+const movieText = response.data.items[0].elements.title.value;
 ```
 
 ## HTML & UMD & CDN


### PR DESCRIPTION


### Motivation

I confirmed with @Enngage  that item elements are now found within elements `response.data.items[0].elements.title` rather than directly in the item. `response.data.items[0].title` So I updated the TypeScript and JavaScript examples to reflect this change.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

No testing required
