### PR TITLE
Add type imports (to avoid disabled import elision)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ https://cdn.jsdelivr.net/npm/@kontent-ai/delivery-sdk@latest/dist/bundles/konten
 ## TypeScript & ES6
 
 ```typescript
-import { IContentItem, Elements, createDeliveryClient } from '@kontent-ai/delivery-sdk';
+import { type IContentItem, type Elements, createDeliveryClient } from '@kontent-ai/delivery-sdk';
 
 /**
  * Defining models is optional, but will greatly benefit development


### PR DESCRIPTION
### Motivation

When using in codebase with `preserveValueImports` and `isolatedModules` is required to use type only import. For more info see:
* https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#preserve-value-imports
* https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#disabling-import-elision

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [X] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
**no**