### PR TITLE
KCL-9696 - deliver js sdk timezone

### DIFF
--- a/lib/contracts/contracts.ts
+++ b/lib/contracts/contracts.ts
@@ -67,6 +67,13 @@ export namespace Contracts {
         taxonomy_group?: string;
     }
 
+    export interface IDateTimeElementContract extends IElementContract {
+        /**
+         * Display time zone
+         */
+        display_timezone: string;
+    }
+
     export interface IAsssetRenditionContract {
         rendition_id: string;
         preset_id: string;

--- a/lib/elements/elements.ts
+++ b/lib/elements/elements.ts
@@ -15,7 +15,12 @@ export namespace Elements {
 
     export type MultipleChoiceElement = ElementModels.IElement<ElementModels.MultipleChoiceOption[]>;
 
-    export type DateTimeElement = ElementModels.IElement<string | null>;
+    export type DateTimeElement = ElementModels.IElement<string | null> & {
+        /**
+         * Display time zone
+         */
+        displayTimeZone: string | null;
+    }
 
     export type RichTextElement = ElementModels.IElement<string> & {
         /**

--- a/lib/mappers/element.mapper.ts
+++ b/lib/mappers/element.mapper.ts
@@ -233,7 +233,11 @@ export class ElementMapper {
     }
 
     private mapDateTimeElement(elementWrapper: ElementModels.IElementWrapper): Elements.DateTimeElement {
-        return this.buildElement(elementWrapper, ElementType.DateTime, () => elementWrapper.rawElement.value);
+        const rawElement = elementWrapper.rawElement as Contracts.IDateTimeElementContract;
+        return {
+            ...this.buildElement(elementWrapper, ElementType.DateTime, () => rawElement.value),
+            displayTimeZone: rawElement.display_timezone ?? null
+        };
     }
 
     private mapMultipleChoiceElement(elementWrapper: ElementModels.IElementWrapper): Elements.MultipleChoiceElement {

--- a/test/browser/isolated-tests/fake-data/fake-warrior-response.json
+++ b/test/browser/isolated-tests/fake-data/fake-warrior-response.json
@@ -60,7 +60,8 @@
       "released": {
         "type": "date_time",
         "name": "Released",
-        "value": "2011-09-09T00:00:00Z"
+        "value": "2011-09-09T00:00:00Z",
+        "display_timezone": "Europe/London"
       },
       "length": {
         "type": "number",

--- a/test/browser/isolated-tests/resolvers/property-name/property-resolver.spec.ts
+++ b/test/browser/isolated-tests/resolvers/property-name/property-resolver.spec.ts
@@ -40,6 +40,7 @@ describe('Property resolver', () => {
     });
 
     it(`checks element is assigned #2`, () => {
+        expect(response.item.elements.test_released.displayTimeZone).toEqual('Europe/London');
         expect(response.item.elements.test_released.value).toEqual('2011-09-09T00:00:00Z');
     });
 

--- a/test/browser/isolated-tests/response/item.spec.ts
+++ b/test/browser/isolated-tests/response/item.spec.ts
@@ -84,6 +84,7 @@ describe('Verifies mapping of delivery content item', () => {
 
     it(`checks datetime element`, () => {
         expect(responseWithLinkedItems.item.elements.released.value).toEqual(warriorJson.item.elements.released.value);
+        expect(responseWithLinkedItems.item.elements.released.displayTimeZone).toEqual(warriorJson.item.elements.released.display_timezone);
     });
 
     it(`checks number element`, () => {


### PR DESCRIPTION
### Motivation
Time zone of date time element is now available in Deliver API. This PR adds the support of time zone for JS SDK. So when user uses this SDK to retrieve DateTime element, the element should contain new property "displayTimeZone". This property is either null or one of time zone ids (see DateTimeInItem: https://kontent.ai/learn/reference/delivery-api/#section/Custom-element). 


Issue:
[KCL-9696](https://kontent-ai.atlassian.net/browse/KCL-9696?atlOrigin=eyJpIjoiYzA1OWRjYWNmYmQ4NGRmYThjNmVlYTZjODdlYzEyNGEiLCJwIjoiaiJ9)

Parrent task:
[KCL-9687](https://kontent-ai.atlassian.net/browse/KCL-9687?atlOrigin=eyJpIjoiYzY2MWJmODMwMjM2NGNhZTljNmEzYWI5OTNhZDhiN2MiLCJwIjoiaiJ9)

Contact Marek Radiměřský if needed.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test
Current tests have been extended. No manual testing is required.
