### PR TITLE
 Fix Typo: worfklowStepCodenames ➜ workflowStepCodenames in item-models.ts

### DIFF
--- a/lib/models/item-models.ts
+++ b/lib/models/item-models.ts
@@ -175,7 +175,7 @@ export interface IUsedInItemRecord<TClientTypes extends ClientTypes> {
         readonly type: TClientTypes['contentTypeCodenames'];
         readonly collection: TClientTypes['collectionCodenames'];
         readonly workflow: TClientTypes['workflowCodenames'];
-        readonly workflowStep: TClientTypes['worfklowStepCodenames'];
+        readonly workflowStep: TClientTypes['workflowStepCodenames'];
         readonly lastModified: string;
     };
 }
@@ -184,7 +184,7 @@ export type ClientTypes = {
     readonly contentItemType: IContentItem;
     readonly contentTypeCodenames: string;
     readonly workflowCodenames: string;
-    readonly worfklowStepCodenames: string;
+    readonly workflowStepCodenames: string;
     readonly collectionCodenames: string;
     readonly taxonomyCodenames: string;
     readonly languageCodenames: string;


### PR DESCRIPTION
Motivation
Fixes #406 

This PR corrects a typo in the "_lib/models/item-models.ts_" file where "_workflowStepCodenames_" was misspelled as "_wor**fk**lowStepCodenames_" (letters "f" and "k" swapped).

The typo appeared in:
The ClientTypes type definition.
The IUsedInItemRecord interface.

Correcting this improves code clarity and prevents potential confusion or errors for SDK consumers.

Checklist
 Code follows coding conventions held in this repo
 Tests are passing
 Docs have been updated (Not applicable)
 Temporary settings reverted (No temp settings used)

How to test
No manual testing required — this is a fix in TypeScript type definitions.

